### PR TITLE
Remove the hard coding of the site name and use the general_sitename settings.

### DIFF
--- a/views/layout/_navigation.cfm
+++ b/views/layout/_navigation.cfm
@@ -4,7 +4,7 @@
 <cfoutput>
 <header>
   <nav class="navbar navbar-expand-lg navbar-light bg-light">
-  #linkTo(route="root", class="navbar-brand", text="Example App")#
+  #linkTo(route="root", class="navbar-brand", text=getSetting('general_sitename'))#
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="##navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>


### PR DESCRIPTION
_navigation.cfm was using a hard coded site name. This change replaces the hard coded name with the general_sitename settings value.